### PR TITLE
Set note title to first line of note when exporting to Evernote

### DIFF
--- a/filters/textfilters.py
+++ b/filters/textfilters.py
@@ -1,0 +1,12 @@
+from google.appengine.ext import webapp
+
+register = webapp.template.create_template_register()
+
+@register.filter
+def firstline(value):
+  # return the first line of value.
+  # If value is a single line, just return it, unchanged.
+  if value.count("\n") == 0:
+    return value
+  else:
+    return value.split("\n")[0]

--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ from django.utils import simplejson
 from google.appengine.ext import webapp
 from google.appengine.ext.webapp import template
 
+template.register_template_library('filters.textfilters')
+
 class Auth(BetterHandler):
   def post(self):
     email = self.request.get('email')

--- a/templates/enex
+++ b/templates/enex
@@ -3,7 +3,7 @@
 <en-export export-date="{% now "Ymd\THis\Z" %}" application="Evernote" version="Evernote Mac 1.4.5 (52531)">
 {% for note in notes %}
   <note>
-    <title>{{ note.content|truncatewords:4 }}</title>
+    <title>{{ note.content|firstline }}</title>
     <content><![CDATA[<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml.dtd"><en-note><div>{{ note.content|fix_ampersands }}</div></en-note>]]></content>
     <created>{{ note.created|date:"Ymd\THis\Z" }}</created>
     <updated>{{ note.modified|date:"Ymd\THis\Z" }}</updated>


### PR DESCRIPTION
Thanks for making simplenote backup available - great use of Google App Engine.

I used it today and wished that, when exporting for Evernote, the note title would be the first line of the note, rather than the first 4 words.

So here's a tiny modification to do that; I've added a custom filter since Django templates don't seem to have a 'first line of string' filter.

Would be honoured if you accepted this modification - I feel it's more consistent with the way that Simple Note handles things.

Best regards,

Richard
